### PR TITLE
Fixed encoding issue in Tensors class to_string() method

### DIFF
--- a/pyvtk/Tensors.py
+++ b/pyvtk/Tensors.py
@@ -24,9 +24,9 @@ class Tensors(DataSetAttr.DataSetAttr):
         self.tensors = self.get_3_3_tuple_list(tensors,(self.default_value,)*3)
     def to_string(self,format='ascii'):
         t = self.get_datatype(self.tensors)
-        ret = ['TENSORS %s %s'%(self.name,t),
+        ret = [('TENSORS %s %s'%(self.name,t)).encode(),
                self.seq_to_string(self.tensors,format,t)]
-        return '\n'.join(ret)
+        return b'\n'.join(ret)
     def get_size(self):
         return len(self.tensors)
 


### PR DESCRIPTION
In Python 3.5, when trying to write a tensor, I get the following error message:

```
 File "/home/hakostra/.local/lib/python3.5/site-packages/pyvtk/__init__.py", line 203, in tofile
    f.write(self.to_string(format))
  File "/home/hakostra/.local/lib/python3.5/site-packages/pyvtk/__init__.py", line 187, in to_string
    ret.append(self.point_data.to_string(format))
  File "/home/hakostra/.local/lib/python3.5/site-packages/pyvtk/Data.py", line 46, in to_string
    ret += [a.to_string(format) for a in self.data]
  File "/home/hakostra/.local/lib/python3.5/site-packages/pyvtk/Data.py", line 46, in <listcomp>
    ret += [a.to_string(format) for a in self.data]
  File "/home/hakostra/.local/lib/python3.5/site-packages/pyvtk/Tensors.py", line 29, in to_string
    return '\n'.join(ret)
TypeError: sequence item 1: expected str instance, bytes found
```

Looking at the same routine in the Scalars and Vectors class, I notice some small differences, and implementing these in the Tensors class efficiently solve the problem.

This is tested in Python version 2.7.12 and 3.5.2 to be working.
