### PR TITLE
_check_int_seq would fail when cell index was not int or np.int_

### DIFF
--- a/examples/unstructured.py
+++ b/examples/unstructured.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# Test example to generate 2D (embedded in 3D) and 3D Delaunay triangulations that output to VTK
+
+import pyvtk
+import numpy as np
+from scipy.spatial import Delaunay
+
+# Generate the random points
+npoints = 1000
+np.random.seed(1)
+x = np.random.normal(size=npoints)*np.pi
+y = np.random.normal(size=npoints)*np.pi
+z = np.sin((x))+np.cos((y))
+# Generate random data
+pointPressure = np.random.rand(npoints)
+
+# Compute the 2D Delaunay triangulation in the x-y plane
+xTmp=list(zip(x,y))
+tri=Delaunay(xTmp)
+
+# Generate Cell Data
+nCells=tri.nsimplex
+cellTemp=np.random.rand(nCells)
+
+# Zip the point co-ordinates for the VtkData input
+points=list(zip(x,y,z))
+
+vtk = pyvtk.VtkData(\
+  pyvtk.UnstructuredGrid(points,
+    triangle=tri.simplices
+    ),
+  pyvtk.PointData(pyvtk.Scalars(pointPressure,name='Pressure')),
+  pyvtk.CellData(pyvtk.Scalars(cellTemp,name='Temperature')),
+  '2D Delaunay Example'
+  )
+vtk.tofile('Delaunay2D')
+vtk.tofile('Delaunay2Db','binary')
+
+# Compute the 3D Delaunay triangulation in the x-y plane
+xTmp=list(zip(x,y,z))
+tri=Delaunay(xTmp)
+
+# Generate Cell Data
+nCells=tri.nsimplex
+cellTemp=np.random.rand(nCells)
+
+# Zip the point co-ordinates for the VtkData input
+points=list(zip(x,y,z))
+
+vtk = pyvtk.VtkData(\
+  pyvtk.UnstructuredGrid(points,
+    tetra=tri.simplices
+    ),
+  pyvtk.PointData(pyvtk.Scalars(pointPressure,name='Pressure')),
+  pyvtk.CellData(pyvtk.Scalars(cellTemp,name='Temperature')),
+  '3D Delaunay Example'
+  )
+vtk.tofile('Delaunay3D')
+vtk.tofile('Delaunay3Db','binary')

--- a/pyvtk/DataSet.py
+++ b/pyvtk/DataSet.py
@@ -22,6 +22,8 @@ import pyvtk.TextureCoordinates as TextureCoordinates
 import pyvtk.Tensors as Tensors
 import pyvtk.Field as Field
 
+from numpy import issubdtype,integer
+
 class DataSet(common.Common):
     """Abstract class.
     It describes the geometry and topology of VTK dataset.
@@ -65,6 +67,9 @@ class DataSet(common.Common):
                 return 1
         return 0
     def _check_int_seq(self,obj,mx_int):
+        if (hasattr(obj,'dtype')):
+            if issubdtype(obj.dtype,integer):
+                return 1 if obj.max() >= mx_int else 0
         if common.is_sequence(obj):
             for o in obj:
                 if self._check_int_seq(o,mx_int):


### PR DESCRIPTION
Added support for numpy integers when checking datas sets. The example “unstructured.py” would fail because _check_int_seq would compare an np.int32 with int or np.int_ because scipy's delaunay triangulation returns an ndarray of np.int32

Since all elements of the numpy array must be the same, returning early prevents checking each element.

After edits, I tested example1 and 2. Both ran.  Example 3 threw an error unrelated to this pull request.